### PR TITLE
New rule rds-instance-public-access-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following AWS Config Rules are supported:
 |------|-------------|:----:|:-----:|:-----:|
 | acm\_days\_to\_expiration | Specify the number of days before the rule flags the ACM Certificate as noncompliant. | string | `"14"` | no |
 | check\_guard\_duty | Enable guardduty-enabled-centralized rule | string | `"false"` | no |
+| check\_rds\_public\_access | Enable rds-instance-public-access-check rule | string | `"false"` | no |
 | config\_delivery\_frequency | The frequency with which AWS Config delivers configuration snapshots. | string | `"Six_Hours"` | no |
 | config\_logs\_bucket | The S3 bucket for AWS Config logs. | string | n/a | yes |
 | config\_logs\_prefix | The S3 prefix for AWS Config logs. | string | `"config"` | no |

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -143,6 +143,20 @@ resource "aws_config_config_rule" "rds-storage-encrypted" {
   depends_on = ["aws_config_configuration_recorder.main"]
 }
 
+resource "aws_config_config_rule" "rds-instance-public-access-check" {
+  count = "${var.check_rds_public_access}"
+
+  name        = "rds-instance-public-access-check"
+  description = "Checks whether the Amazon Relational Database Service (RDS) instances are not publicly accessible. The rule is non-compliant if the publiclyAccessible field is true in the instance configuration item."
+
+  source {
+    owner             = "AWS"
+    source_identifier = "RDS_INSTANCE_PUBLIC_ACCESS_CHECK"
+  }
+
+  depends_on = ["aws_config_configuration_recorder.main"]
+}
+
 resource "aws_config_config_rule" "rds-snapshots-public-prohibited" {
   name        = "rds-snapshots-public-prohibited"
   description = "Checks if Amazon Relational Database Service (Amazon RDS) snapshots are public."

--- a/variables.tf
+++ b/variables.tf
@@ -65,3 +65,8 @@ variable "check_guard_duty" {
   description = "Enable guardduty-enabled-centralized rule"
   default     = false
 }
+
+variable "check_rds_public_access" {
+  description = "Enable rds-instance-public-access-check rule"
+  default     = false
+}


### PR DESCRIPTION
Added `rds-instance-public-access-check` rule.  Off by default, but can be enabled with `check_rds_public_access` variable.