### PR TITLE
Add rule to check for EIP attached rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following AWS Config Rules are supported:
 | aggregate\_organization | Aggregate compliance data by organization | string | `"false"` | no |
 | check\_cloud\_trail\_encryption | Enable cloud-trail-encryption-enabled rule | string | `"false"` | no |
 | check\_cloud\_trail\_log\_file\_validation | Enable cloud-trail-log-file-validation-enabled rule | string | `"false"` | no |
+| check\_eip\_attached | Enable eip-attached rule | string | `"false"` | no |
 | check\_guard\_duty | Enable guardduty-enabled-centralized rule | string | `"false"` | no |
 | check\_multi\_region\_cloud\_trail | Enable multi-region-cloud-trail-enabled rule | string | `"false"` | no |
 | check\_rds\_public\_access | Enable rds-instance-public-access-check rule | string | `"false"` | no |

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -262,3 +262,17 @@ resource "aws_config_config_rule" "s3-bucket-public-write-prohibited" {
 
   depends_on = ["aws_config_configuration_recorder.main"]
 }
+
+resource "aws_config_config_rule" "eip_attached" {
+  count = "${var.check_eip_attached ? 1 : 0}"
+
+  name        = "eip-attached"
+  description = "Checks whether all Elastic IP addresses that are allocated to a VPC are attached to EC2 instances or in-use elastic network interfaces (ENIs)."
+
+  source {
+    owner             = "AWS"
+    source_identifier = "EIP_ATTACHED"
+  }
+
+  depends_on = ["aws_config_configuration_recorder.main"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -97,3 +97,8 @@ variable "check_cloud_trail_log_file_validation" {
   description = "Enable cloud-trail-log-file-validation-enabled rule"
   default     = false
 }
+
+variable "check_eip_attached" {
+  description = "Enable eip-attached rule"
+  default     = false
+}


### PR DESCRIPTION
Adding a new rule to monitor our EIPs to ensure they are attached. This came up in a security review and seems like an easy rule to have. It's off by default.

https://docs.aws.amazon.com/config/latest/developerguide/eip-attached.html