### PR TITLE
Move AWS Config name to a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ module "aws_config" {
 | config\_logs\_bucket | The S3 bucket for AWS Config logs. | string | n/a | yes |
 | config\_logs\_prefix | The S3 prefix for AWS Config logs. | string | `"config"` | no |
 | config\_max\_execution\_frequency | The maximum frequency with which AWS Config runs evaluations for a rule. | string | `"TwentyFour_Hours"` | no |
+| config\_name | The name of the AWS Config instance. | string | `"aws-config"` | no |
 | password\_max\_age | Number of days before password expiration. | string | `"90"` | no |
 | password\_min\_length | Password minimum length. | string | `"14"` | no |
 | password\_require\_lowercase | Require at least one lowercase character in password. | string | `"true"` | no |

--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ Terraform 0.11. Pin module version to ~> 1.5.1. Submit pull-requests to terrafor
 
 ## Usage
 
+**Note: This module sets up AWS IAM Roles and Policies, which are globally namespaced. If you plan to have multiple instances of AWS Config, make sure they have unique values for `config_name`.**
+
 ```hcl
 module "aws_config" {
-  source             = "trussworks/config/aws"
+  source = "trussworks/config/aws"
+
+  config_name        = "my-aws-config"
   config_logs_bucket = "my-aws-logs"
 }
 ```

--- a/config-aggregator.tf
+++ b/config-aggregator.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "aws_config_aggregator_role_policy" {
 
 resource "aws_iam_role" "aggregator" {
   count              = var.aggregate_organization ? 1 : 0
-  name               = "aws-config-aggregator-role"
+  name               = "${var.config_name}-aggregator-role"
   assume_role_policy = data.aws_iam_policy_document.aws_config_aggregator_role_policy.json
 }
 

--- a/config-service.tf
+++ b/config-service.tf
@@ -3,13 +3,13 @@
 #
 
 resource "aws_config_configuration_recorder_status" "main" {
-  name       = "aws-config"
+  name       = var.config_name
   is_enabled = true
   depends_on = [aws_config_delivery_channel.main]
 }
 
 resource "aws_config_delivery_channel" "main" {
-  name           = "aws-config"
+  name           = var.config_name
   s3_bucket_name = var.config_logs_bucket
   s3_key_prefix  = var.config_logs_prefix
 
@@ -21,7 +21,7 @@ resource "aws_config_delivery_channel" "main" {
 }
 
 resource "aws_config_configuration_recorder" "main" {
-  name     = "aws-config"
+  name     = var.config_name
   role_arn = aws_iam_role.main.arn
 
   recording_group {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -15,6 +15,7 @@ module "config_logs" {
 module "config" {
   source = "../../"
 
+  config_name        = var.config_name
   config_logs_bucket = "${module.config_logs.aws_logs_bucket}"
   config_logs_prefix = "config"
 }

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -1,3 +1,7 @@
+variable "config_name" {
+  type = "string"
+}
+
 variable "config_logs_bucket" {
   type = "string"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -66,23 +66,23 @@ data "aws_iam_policy_document" "aws-config-role-policy" {
 #
 
 resource "aws_iam_role" "main" {
-  name               = "aws-config-role"
+  name               = "${var.config_name}-role"
   assume_role_policy = data.aws_iam_policy_document.aws-config-role-policy.json
 }
 
 resource "aws_iam_policy_attachment" "managed-policy" {
-  name       = "aws-config-managed-policy"
+  name       = "${var.config_name}-managed-policy"
   roles      = [aws_iam_role.main.name]
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
 }
 
 resource "aws_iam_policy" "aws-config-policy" {
-  name   = "aws-config-policy"
+  name   = "${var.config_name}-policy"
   policy = data.template_file.aws_config_policy.rendered
 }
 
 resource "aws_iam_policy_attachment" "aws-config-policy" {
-  name       = "aws-config-policy"
+  name       = "${var.config_name}-policy"
   roles      = [aws_iam_role.main.name]
   policy_arn = aws_iam_policy.aws-config-policy.arn
 }

--- a/test/terraform_aws_config_test.go
+++ b/test/terraform_aws_config_test.go
@@ -13,14 +13,16 @@ import (
 func TestTerraformAwsConfig(t *testing.T) {
 	t.Parallel()
 
-	expectedConfigLogsBucket := fmt.Sprintf("terratest-aws-config-%s", strings.ToLower(random.UniqueId()))
-	awsRegion := aws.GetRandomStableRegion(t, nil, nil)
+	configName := fmt.Sprintf("aws-config-%s", strings.ToLower(random.UniqueId()))
+	expectedConfigLogsBucket := fmt.Sprintf("terratest-%s", configName)
+	awsRegion := "us-west-2"
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/simple/",
 		Vars: map[string]interface{}{
 			"region":             awsRegion,
 			"config_logs_bucket": expectedConfigLogsBucket,
+			"config_name":        configName,
 		},
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": awsRegion,
@@ -28,8 +30,10 @@ func TestTerraformAwsConfig(t *testing.T) {
 	}
 
 	defer terraform.Destroy(t, terraformOptions)
-	terraform.InitAndApply(t, terraformOptions)
 
 	// Empty config_logs_bucket before terraform destroy
-	aws.EmptyS3Bucket(t, awsRegion, expectedConfigLogsBucket)
+	defer aws.EmptyS3Bucket(t, awsRegion, expectedConfigLogsBucket)
+
+	terraform.InitAndApply(t, terraformOptions)
+
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "config_name" {
+  description = "The name of the AWS Config instance."
+  type        = string
+  default     = "aws-config"
+}
+
 variable "config_aggregator_name" {
   description = "The name of the aggregator."
   type        = string


### PR DESCRIPTION
As we start to add more parallel tests to this module, we are hitting global naming conflict. The immediate conflicts occur in IAM role/policy naming, which are global. This PR paramterizes the AWS Config Service name, but leave the default to be `aws-config`. I've also updated the tests to only use `us-west-2` and adding a defer to empty the bucket. 

```
--- PASS: TestTerraformAwsConfig (201.02s)
PASS
ok  	github.com/trussworks/terraform-aws-config/test	201.394s
```