### PR TITLE
Ensure required-tags rule is enabled and assert it

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ module "aws_config" {
 | required\_tags | A map of required resource tags. Format is tagNKey, tagNValue, where N is int. Values are optional. | map(string) | `{}` | no |
 | required\_tags\_resource\_types | Resource types to check for tags. | list(string) | `[]` | no |
 
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| required\_tags\_rule\_arn | The ARN of the required-tags config rule. |
+
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Developer Setup

--- a/examples/required-tags/main.tf
+++ b/examples/required-tags/main.tf
@@ -19,6 +19,7 @@ module "config" {
   config_logs_bucket = "${module.config_logs.aws_logs_bucket}"
   config_logs_prefix = "config"
 
+  check_required_tags          = true
   required_tags_resource_types = ["S3::Bucket"]
   required_tags = {
     tag1Key   = "Automation"

--- a/examples/required-tags/outputs.tf
+++ b/examples/required-tags/outputs.tf
@@ -1,0 +1,4 @@
+output "required_tags_rule_arn" {
+  value = module.config.required_tags_rule_arn
+}
+

--- a/examples/simple/outputs.tf
+++ b/examples/simple/outputs.tf
@@ -1,0 +1,4 @@
+output "required_tags_rule_arn" {
+  value = module.config.required_tags_rule_arn
+}
+

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/trussworks/terraform-aws-config
 
 go 1.13
 
-require github.com/gruntwork-io/terratest v0.23.0
+require (
+	github.com/gruntwork-io/terratest v0.23.0
+	github.com/stretchr/testify v1.4.0
+)

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,5 @@
+output "required_tags_rule_arn" {
+  description = "The ARN of the required-tags config rule."
+  value       = concat(aws_config_config_rule.required-tags.*.arn, [""])[0]
+}
+

--- a/test/terraform_aws_config_test.go
+++ b/test/terraform_aws_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTerraformAwsConfig(t *testing.T) {
@@ -44,6 +45,9 @@ func TestTerraformAwsConfig(t *testing.T) {
 
 	terraform.InitAndApply(t, terraformOptions)
 
+	requiredTagsRuleARN := terraform.Output(t, terraformOptions, "required_tags_rule_arn")
+	assert.Empty(t, requiredTagsRuleARN)
+
 }
 
 func TestRequiredTags(t *testing.T) {
@@ -76,4 +80,8 @@ func TestRequiredTags(t *testing.T) {
 	defer aws.EmptyS3Bucket(t, awsRegion, expectedConfigLogsBucket)
 
 	terraform.InitAndApply(t, terraformOptions)
+
+	requiredTagsRuleARN := terraform.Output(t, terraformOptions, "required_tags_rule_arn")
+	assert.NotEmpty(t, requiredTagsRuleARN)
+
 }


### PR DESCRIPTION
This tests out using outputs to test out the resource we expect are actually created, in this case the required-tags config rule. There's a bit of hackery in the outputs.tf because `aws_config_config_rule.required-tags` relies on a conditional count, which makes it a list of resources. 

```
--- PASS: TestTerraformAwsConfig (182.17s)
--- PASS: TestRequiredTags (187.03s)
PASS
ok  	github.com/trussworks/terraform-aws-config/test	187.325s
```