### PR TITLE
Move tests to ca-central-1 and eu-west-1

### DIFF
--- a/test/terraform_aws_config_test.go
+++ b/test/terraform_aws_config_test.go
@@ -24,7 +24,7 @@ func TestTerraformAwsConfig(t *testing.T) {
 
 	// AWS only supports one configuration recorder per region.
 	// Each test will need to specify a different region.
-	awsRegion := "us-west-2"
+	awsRegion := "us-east-1"
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
@@ -62,7 +62,7 @@ func TestRequiredTags(t *testing.T) {
 
 	// AWS only supports one configuration recorder per region.
 	// Each test will need to specify a different region.
-	awsRegion := "us-east-1"
+	awsRegion := "us-east-2"
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,

--- a/test/terraform_aws_config_test.go
+++ b/test/terraform_aws_config_test.go
@@ -24,7 +24,7 @@ func TestTerraformAwsConfig(t *testing.T) {
 
 	// AWS only supports one configuration recorder per region.
 	// Each test will need to specify a different region.
-	awsRegion := "us-east-1"
+	awsRegion := "ca-central-1"
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
@@ -62,7 +62,7 @@ func TestRequiredTags(t *testing.T) {
 
 	// AWS only supports one configuration recorder per region.
 	// Each test will need to specify a different region.
-	awsRegion := "us-east-2"
+	awsRegion := "eu-west-1"
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,


### PR DESCRIPTION
AWS Config has this funny limitation where you can only max of one Config recorder instance in a region. We recently turned on a long lived instance of AWS Config in us-west-2, which causes these tests to fail. So sadly I need to move the regions. 

```
ok  	github.com/trussworks/terraform-aws-config/test	195.584s
```