### PR TITLE
Updating for govcloud compatibility

### DIFF
--- a/config-aggregator.tf
+++ b/config-aggregator.tf
@@ -24,7 +24,7 @@ resource "aws_iam_role" "aggregator" {
 resource "aws_iam_role_policy_attachment" "aggregator" {
   count      = var.aggregate_organization ? 1 : 0
   role       = aws_iam_role.aggregator[0].name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations"
+  policy_arn = format("arn:%s:iam::aws:policy/service-role/AWSConfigRoleForOrganizations", data.aws_partition.current.partition)
 }
 
 #

--- a/iam.tf
+++ b/iam.tf
@@ -37,9 +37,10 @@ data "template_file" "aws_config_policy" {
 JSON
 
   vars = {
-    bucket_arn = format("arn:aws:s3:::%s", var.config_logs_bucket)
+    bucket_arn = format("arn:%s:s3:::%s", data.aws_partition.current.partition, var.config_logs_bucket)
     resource = format(
-      "arn:aws:s3:::%s/%s/AWSLogs/%s/Config/*",
+      "arn:%s:s3:::%s/%s/AWSLogs/%s/Config/*",
+      data.aws_partition.current.partition,
       var.config_logs_bucket,
       var.config_logs_prefix,
       data.aws_caller_identity.current.account_id,
@@ -73,7 +74,7 @@ resource "aws_iam_role" "main" {
 resource "aws_iam_policy_attachment" "managed-policy" {
   name       = "${var.config_name}-managed-policy"
   roles      = [aws_iam_role.main.name]
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
+  policy_arn = format("arn:%s:iam::aws:policy/service-role/AWSConfigRole", data.aws_partition.current.partition)
 }
 
 resource "aws_iam_policy" "aws-config-policy" {

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,1 @@
+data "aws_partition" "current" {}


### PR DESCRIPTION
I've updated this to work with GovCloud; I've tested this in our GovCloud account and it works. One note being that `root-account-mfa-enabled` is not a valid config option in GovCloud, and I'm trying to figure out the best way to handle that (for now you can just set it to `false` and it works fine).