### PR TITLE
Add root access key, public ebs and default security group rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Enables AWS Config and adds managed config rules with good defaults.
 * iam-user-no-policies-check: Ensure that none of your IAM users have policies attached; IAM users must inherit permissions from IAM groups or roles.
 * iam-group-has-users-check: Checks whether IAM groups have at least one IAM user.
 * root-account-mfa-enabled: Ensure root AWS account has MFA enabled.
+* iam-root-access-key: Ensure root AWS account does not have Access Keys.
 
 ### Tagging
 
@@ -104,6 +105,7 @@ module "aws_config" {
 | check\_guard\_duty | Enable guardduty-enabled-centralized rule | `bool` | `false` | no |
 | check\_iam\_group\_has\_users\_check | Enable iam-group-has-users-check rule | `bool` | `true` | no |
 | check\_iam\_password\_policy | Enable iam-password-policy rule | `bool` | `true` | no |
+| check\_iam\_root\_access\_key | Enable iam-root-access-key rule | `bool` | `true` | no |
 | check\_iam\_user\_no\_policies\_check | Enable iam-user-no-policies-check rule | `bool` | `true` | no |
 | check\_instances\_in\_vpc | Enable instances-in-vpc rule | `bool` | `true` | no |
 | check\_multi\_region\_cloud\_trail | Enable multi-region-cloud-trail-enabled rule | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ module "aws_config" {
 | check\_cloud\_trail\_log\_file\_validation | Enable cloud-trail-log-file-validation-enabled rule | `bool` | `false` | no |
 | check\_cloudtrail\_enabled | Enable cloudtrail-enabled rule | `bool` | `true` | no |
 | check\_cloudwatch\_log\_group\_encrypted | Enable cloudwatch-log-group-encryption rule | `bool` | `true` | no |
+| check\_ebs\_snapshot\_public\_restorable | Enable ebs-snapshot-public-restorable rule | `bool` | `true` | no |
 | check\_ec2\_encrypted\_volumes | Enable ec2-encrypted-volumes rule | `bool` | `true` | no |
 | check\_ec2\_volume\_inuse\_check | Enable ec2-volume-inuse-check rule | `bool` | `true` | no |
 | check\_eip\_attached | Enable eip-attached rule | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ Enables AWS Config and adds managed config rules with good defaults.
 ### EC2
 
 * ec2-encrypted-volumes: Evaluates whether EBS volumes that are in an attached state are encrypted.
-* ec2-volume-inuse-check: Checks whether EBS volumes are attached to EC2 instances
+* ec2-volume-inuse-check: Checks whether EBS volumes are attached to EC2 instances.
+* ebs-snapshot-public-restorable-check: Checks whether Amazon Elastic Block Store snapshots are not publicly restorable.
 
 ### VPC
 
-* eip_attached: Checks whether all EIP addresses that are allocated to a VPC are attached to EC2 or in-use ENIs.
+* eip-attached: Checks whether all EIP addresses that are allocated to a VPC are attached to EC2 or in-use ENIs.
 * instances-in-vpc: Ensure all EC2 instances run in a VPC.
+* vpc-default-security-group-closed: Checks that the default security group of any Amazon Virtual Private Cloud (VPC) does not allow inbound or outbound traffic.
 
 ### GuardDuty
 
@@ -116,6 +118,7 @@ module "aws_config" {
 | check\_required\_tags | Enable required-tags rule | `bool` | `false` | no |
 | check\_root\_account\_mfa\_enabled | Enable root-account-mfa-enabled rule | `bool` | `false` | no |
 | check\_s3\_bucket\_public\_write\_prohibited | Enable s3-bucket-public-write-prohibited rule | `bool` | `true` | no |
+| check\_vpc\_default\_security\_group\_closed | Enable vpc-default-security-group-closed rule | `bool` | `true` | no |
 | config\_aggregator\_name | The name of the aggregator. | `string` | `"organization"` | no |
 | config\_delivery\_frequency | The frequency with which AWS Config delivers configuration snapshots. | `string` | `"Six_Hours"` | no |
 | config\_logs\_bucket | The S3 bucket for AWS Config logs. | `string` | n/a | yes |

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -354,3 +354,17 @@ resource "aws_config_config_rule" "cloudwatch_log_group_encrypted" {
 
   depends_on = [aws_config_configuration_recorder.main]
 }
+
+resource "aws_config_config_rule" "iam_root_access_key" {
+  count = var.check_iam_root_access_key_check ? 1 : 0
+
+  name        = "iam-root-access-key"
+  description = "Checks whether the root user access key is available. The rule is COMPLIANT if the user access key does not exist"
+
+  source {
+    owner             = "AWS"
+    source_identifier = "IAM_ROOT_ACCESS_KEY_CHECK"
+  }
+
+  depends_on = [aws_config_configuration_recorder.main]
+}

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -168,6 +168,19 @@ resource "aws_config_config_rule" "ec2-volume-inuse-check" {
   depends_on = [aws_config_configuration_recorder.main]
 }
 
+resource "aws_config_config_rule" "ebs_snapshot_public_restorable" {
+  count       = var.check_ebs_snapshot_public_restorable ? 1 : 0
+  name        = "ebs-snapshot-public-restorable"
+  description = "Checks whether Amazon Elastic Block Store snapshots are not publicly restorable"
+
+  source {
+    owner             = "AWS"
+    source_identifier = "EBS_SNAPSHOT_PUBLIC_RESTORABLE_CHECK"
+  }
+
+  depends_on = [aws_config_configuration_recorder.main]
+}
+
 resource "aws_config_config_rule" "iam-user-no-policies-check" {
   count       = var.check_iam_user_no_policies_check ? 1 : 0
   name        = "iam-user-no-policies-check"

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -48,10 +48,7 @@ resource "aws_config_config_rule" "iam-password-policy" {
 
   maximum_execution_frequency = var.config_max_execution_frequency
 
-  depends_on = [
-    aws_config_configuration_recorder.main,
-    aws_config_delivery_channel.main,
-  ]
+  depends_on = [aws_config_configuration_recorder.main]
 }
 
 resource "aws_config_config_rule" "cloudtrail-enabled" {
@@ -66,10 +63,7 @@ resource "aws_config_config_rule" "cloudtrail-enabled" {
 
   maximum_execution_frequency = var.config_max_execution_frequency
 
-  depends_on = [
-    aws_config_configuration_recorder.main,
-    aws_config_delivery_channel.main,
-  ]
+  depends_on = [aws_config_configuration_recorder.main]
 }
 
 resource "aws_config_config_rule" "multi-region-cloud-trail-enabled" {
@@ -84,10 +78,7 @@ resource "aws_config_config_rule" "multi-region-cloud-trail-enabled" {
 
   maximum_execution_frequency = var.config_max_execution_frequency
 
-  depends_on = [
-    aws_config_configuration_recorder.main,
-    aws_config_delivery_channel.main,
-  ]
+  depends_on = [aws_config_configuration_recorder.main]
 }
 
 resource "aws_config_config_rule" "cloud-trail-encryption-enabled" {
@@ -102,10 +93,7 @@ resource "aws_config_config_rule" "cloud-trail-encryption-enabled" {
 
   maximum_execution_frequency = var.config_max_execution_frequency
 
-  depends_on = [
-    aws_config_configuration_recorder.main,
-    aws_config_delivery_channel.main,
-  ]
+  depends_on = [aws_config_configuration_recorder.main]
 }
 
 resource "aws_config_config_rule" "cloud-trail-log-file-validation-enabled" {
@@ -120,10 +108,7 @@ resource "aws_config_config_rule" "cloud-trail-log-file-validation-enabled" {
 
   maximum_execution_frequency = var.config_max_execution_frequency
 
-  depends_on = [
-    aws_config_configuration_recorder.main,
-    aws_config_delivery_channel.main,
-  ]
+  depends_on = [aws_config_configuration_recorder.main]
 }
 
 resource "aws_config_config_rule" "instances-in-vpc" {
@@ -136,10 +121,7 @@ resource "aws_config_config_rule" "instances-in-vpc" {
     source_identifier = "INSTANCES_IN_VPC"
   }
 
-  depends_on = [
-    aws_config_configuration_recorder.main,
-    aws_config_delivery_channel.main,
-  ]
+  depends_on = [aws_config_configuration_recorder.main]
 }
 
 resource "aws_config_config_rule" "root-account-mfa-enabled" {
@@ -154,10 +136,7 @@ resource "aws_config_config_rule" "root-account-mfa-enabled" {
 
   maximum_execution_frequency = var.config_max_execution_frequency
 
-  depends_on = [
-    aws_config_configuration_recorder.main,
-    aws_config_delivery_channel.main,
-  ]
+  depends_on = [aws_config_configuration_recorder.main]
 }
 
 resource "aws_config_config_rule" "acm-certificate-expiration-check" {
@@ -356,7 +335,7 @@ resource "aws_config_config_rule" "cloudwatch_log_group_encrypted" {
 }
 
 resource "aws_config_config_rule" "iam_root_access_key" {
-  count = var.check_iam_root_access_key_check ? 1 : 0
+  count = var.check_iam_root_access_key ? 1 : 0
 
   name        = "iam-root-access-key"
   description = "Checks whether the root user access key is available. The rule is COMPLIANT if the user access key does not exist"

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -360,3 +360,17 @@ resource "aws_config_config_rule" "iam_root_access_key" {
 
   depends_on = [aws_config_configuration_recorder.main]
 }
+
+resource "aws_config_config_rule" "vpc_default_security_group_closed" {
+  count = var.check_vpc_default_security_group_closed ? 1 : 0
+
+  name        = "vpc-default-security-group-closed"
+  description = "Checks that the default security group of any Amazon Virtual Private Cloud (VPC) does not allow inbound or outbound traffic"
+
+  source {
+    owner             = "AWS"
+    source_identifier = "VPC_DEFAULT_SECURITY_GROUP_CLOSED"
+  }
+
+  depends_on = [aws_config_configuration_recorder.main]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -242,3 +242,9 @@ variable "check_ebs_snapshot_public_restorable" {
   type        = bool
   default     = true
 }
+
+variable "check_vpc_default_security_group_closed" {
+  description = "Enable vpc-default-security-group-closed rule"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -236,3 +236,9 @@ variable "check_iam_root_access_key" {
   type        = bool
   default     = true
 }
+
+variable "check_ebs_snapshot_public_restorable" {
+  description = "Enable ebs-snapshot-public-restorable rule"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -230,3 +230,9 @@ variable "check_cloudwatch_log_group_encrypted" {
   type        = bool
   default     = true
 }
+
+variable "check_iam_root_access_key" {
+  description = "Enable iam-root-access-key rule"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Adds a couple more config rules we likely want to enable by default.
* ebs-snapshot-public-restorable
* vpc-default-security-group-closed
* iam-root-access-key

I also removed unnecessary `depends_on` resources

**Testing**
```
--- PASS: TestTerraformAwsConfig (201.15s)
PASS
ok  	github.com/trussworks/terraform-aws-config/test	201.570s
```