### PR TITLE
Fix IAM role contamination

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:abca33ce0067fe58a4e33139ae470b65f1cab1f9
+      - image: trussworks/circleci-docker-primary:3ce332312856084283853e50c98a3e68e8241e89
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.23.7
+    rev: v1.24.0
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -143,6 +143,19 @@ module "aws_config" {
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+## Upgrade Paths
+
+### Upgrading from 2.3.0 to 2.4.x
+
+Version 2.4.0 changed how AWS Config IAM polcies would be attached to IAM roles. When applying the upgrade, you will likely see a race condition resulting in the following error
+
+```text
+Error: Provider produced inconsistent result after apply
+```
+
+A second `terraform apply` should resolve the issue.
+
+
 ## Developer Setup
 
 Install dependencies (macOS)

--- a/iam.tf
+++ b/iam.tf
@@ -71,9 +71,8 @@ resource "aws_iam_role" "main" {
   assume_role_policy = data.aws_iam_policy_document.aws-config-role-policy.json
 }
 
-resource "aws_iam_policy_attachment" "managed-policy" {
-  name       = "${var.config_name}-managed-policy"
-  roles      = [aws_iam_role.main.name]
+resource "aws_iam_role_policy_attachment" "managed-policy" {
+  role       = aws_iam_role.main.name
   policy_arn = format("arn:%s:iam::aws:policy/service-role/AWSConfigRole", data.aws_partition.current.partition)
 }
 
@@ -82,9 +81,7 @@ resource "aws_iam_policy" "aws-config-policy" {
   policy = data.template_file.aws_config_policy.rendered
 }
 
-resource "aws_iam_policy_attachment" "aws-config-policy" {
-  name       = "${var.config_name}-policy"
-  roles      = [aws_iam_role.main.name]
+resource "aws_iam_role_policy_attachment" "aws-config-policy" {
+  role       = aws_iam_role.main.name
   policy_arn = aws_iam_policy.aws-config-policy.arn
 }
-


### PR DESCRIPTION
I came across a very strange bug in this module, which surfaces when running multiple instances of the module in the same AWS account. The issue surface when when running Terratest in an account with a log lived AWS Config instance, but could also occur in multi-region use cases. 

**Issue**
If there are two running instances of the module and you try to destroy one of the two instances, the destroy will detach IAM policies from the first instance. This will occur if you run the modules in different regions or terraform state files.

When I looked into this a little more I noticed we are using `aws_iam_policy_attachment` resources and when looking at the terraform docs for the resource, there's a big fat fucking warning about the lack of exclusivity when managing the policy attachments. 

https://www.terraform.io/docs/providers/aws/r/iam_policy_attachment.html

**Fix**
The fix is simply to migrate to `iam_role_policy_attachment`. The upgrade path requires two applies, but I've noted that in the README.  

**Testing**
```
ok  	github.com/trussworks/terraform-aws-config/test	401.171s
```
I've also confirmed the upgrade path in the Truss AWS sandbox account. 