### PR TITLE
Pin aws provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ module "aws_config" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | >= 2.40.0 |
+| aws | ~> 2.70 |
 | template | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.40.0 |
+| aws | ~> 2.70 |
 | template | >= 2.0 |
 
 ## Inputs

--- a/examples/required-tags/providers.tf
+++ b/examples/required-tags/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  version = "~> 2.70"
+}

--- a/examples/simple/providers.tf
+++ b/examples/simple/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  version = "~> 2.70"
+}

--- a/examples/sns-topic/providers.tf
+++ b/examples/sns-topic/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  version = "~> 2.70"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    aws      = ">= 2.40.0"
+    aws      = "~> 2.70"
     template = ">= 2.0"
   }
 }


### PR DESCRIPTION
[Pivotal Story](https://www.pivotaltracker.com/story/show/174129036)
Terratest (or maybe terraform) implicitly chooses the version of a provider to use if its not declared when a test is run. So if an AWS resource is used it will download the latest version of the AWS provider and use it.

This is causing issues in terratest so we need to pin the aws provider version