### PR TITLE
updating the config service policy

### DIFF
--- a/examples/required-tags/main.tf
+++ b/examples/required-tags/main.tf
@@ -4,10 +4,9 @@
 
 module "config_logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 9"
+  version = "~> 10"
 
   s3_bucket_name     = var.config_logs_bucket
-  region             = var.region
   allow_config       = true
   config_logs_prefix = "config"
   force_destroy      = true

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -4,10 +4,9 @@
 
 module "config_logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 9"
+  version = "~> 10"
 
   s3_bucket_name     = var.config_logs_bucket
-  region             = var.region
   allow_config       = true
   config_logs_prefix = "config"
   force_destroy      = true

--- a/examples/sns-topic/main.tf
+++ b/examples/sns-topic/main.tf
@@ -6,10 +6,9 @@ data "aws_partition" "current" {}
 
 module "config_logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 9"
+  version = "~> 10"
 
   s3_bucket_name     = var.config_logs_bucket
-  region             = var.region
   allow_config       = true
   config_logs_prefix = "config"
   force_destroy      = true

--- a/iam.tf
+++ b/iam.tf
@@ -74,7 +74,7 @@ resource "aws_iam_role" "main" {
 
 resource "aws_iam_role_policy_attachment" "managed-policy" {
   role       = aws_iam_role.main.name
-  policy_arn = format("arn:%s:iam::aws:policy/service-role/AWSConfigRole", data.aws_partition.current.partition)
+  policy_arn = format("arn:%s:iam::aws:policy/service-role/AWS_ConfigRole", data.aws_partition.current.partition)
 }
 
 resource "aws_iam_policy" "aws-config-policy" {


### PR DESCRIPTION
Email from AWS "As part of our continued effort to provide AWS customers with fine grained and secure permissions management solutions, AWS Config has published a new managed policy called AWS_ConfigRole that is scheduled to replace and subsequently deprecate AWSConfigRole on December 1, 2020. This new policy removes the "S3:GetObject" permission as AWS Config does not need permissions to read S3 objects.
The AWSConfigRole managed policy will continue working for all currently attached users, groups, and roles. However, effective December 1, 2020, AWSConfigRole managed policy cannot be attached to any new users, groups, or roles. No action is needed if your account does not utilize the AWSConfigRole managed policy."

Also see Issue here: https://github.com/trussworks/terraform-aws-config/issues/85