### PR TITLE
Fix deprecated interpolation-only expression

### DIFF
--- a/config-rules.tf
+++ b/config-rules.tf
@@ -24,7 +24,7 @@ data "template_file" "aws_config_acm_certificate_expiration" {
 }
 
 data "template_file" "aws_config_ami_approved_tag" {
-  template = "${file("${path.module}/config-policies/ami-approved-tag.tpl")}"
+  template = file("${path.module}/config-policies/ami-approved-tag.tpl")
 
   vars = {
     ami_required_tag_key_value = var.ami_required_tag_key_value


### PR DESCRIPTION
This fixes a warning when applying:

```
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/aws_config/config-rules.tf line 27, in data "template_file" "aws_config_ami_approved_tag":
  27:   template = "${file("${path.module}/config-policies/ami-approved-tag.tpl")}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```