### PR TITLE
Relax version constraints for Terraform 0.14 and deprecate Terraform 0.11 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:6986bb9022e5a83599feb66a7128a2d0fa12732a
+      image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
     steps:
     - checkout
     - restore_cache:
@@ -12,11 +12,12 @@ jobs:
         - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
         - go-mod-sources-v1-{{ checksum "go.sum" }}
     - run:
-        command: "temp_role=$(aws sts assume-role \\\n        --role-arn arn:aws:iam::313564602749:role/circleci\
-          \ \\\n        --role-session-name circleci)\nexport AWS_ACCESS_KEY_ID=$(echo\
-          \ $temp_role | jq .Credentials.AccessKeyId | xargs)\nexport AWS_SECRET_ACCESS_KEY=$(echo\
-          \ $temp_role | jq .Credentials.SecretAccessKey | xargs)\nexport AWS_SESSION_TOKEN=$(echo\
-          \ $temp_role | jq .Credentials.SessionToken | xargs)\nmake test\n"
+        command: |
+          temp_role=$(aws sts assume-role --role-arn arn:aws:iam::313564602749:role/circleci --role-session-name circleci)
+          export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+          export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+          export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+          make test
         name: Assume role, run pre-commit and run terratest
     - save_cache:
         key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
@@ -26,8 +27,6 @@ jobs:
         key: go-mod-sources-v1-{{ checksum "go.sum" }}
         paths:
         - ~/go/pkg/mod
-references:
-  circleci: trussworks/circleci:6986bb9022e5a83599feb66a7128a2d0fa12732a
 version: 2.1
 workflows:
   validate:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,7 +12,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.25.0
+    rev: v0.26.0
     hooks:
       - id: markdownlint
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ Terraform 0.13. Pin module version to ~> 4.x. Submit pull-requests to master bra
 
 Terraform 0.12. Pin module version to ~> 3.0. Submit pull-requests to terraform012 branch.
 
-Terraform 0.11. Pin module version to ~> 1.5.1. Submit pull-requests to terraform011 branch.
-
 ## Usage
 
 **Note: This module sets up AWS IAM Roles and Policies, which are globally namespaced. If you plan to have multiple instances of AWS Config, make sure they have unique values for `config_name`.**
@@ -90,15 +88,15 @@ module "aws_config" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.7, < 0.14 |
-| aws | >= 2.70, < 4.0 |
+| terraform | >= 0.12.7 |
+| aws | >= 2.70 |
 | template | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.70, < 4.0 |
+| aws | >= 2.70 |
 | template | >= 2.0 |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Enables AWS Config and adds managed config rules with good defaults.
 
 ## Terraform Versions
 
-Terraform 0.13. Pin module version to ~> 4.x. Submit pull-requests to master branch.
+Terraform 0.13 and newer. Pin module version to ~> 4.x. Submit pull-requests to master branch.
 
 Terraform 0.12. Pin module version to ~> 3.0. Submit pull-requests to terraform012 branch.
 

--- a/examples/required-tags/providers.tf
+++ b/examples/required-tags/providers.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  version = ">= 2.70"
-  region  = var.region
-}

--- a/examples/simple/providers.tf
+++ b/examples/simple/providers.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  version = ">= 2.70"
-  region  = var.region
-}

--- a/examples/sns-topic/providers.tf
+++ b/examples/sns-topic/providers.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  version = ">= 2.70"
-  region  = var.region
-}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/trussworks/terraform-aws-config
 
-go 1.14
+go 1.15
 
 require (
 	github.com/gruntwork-io/terratest v0.31.1

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.7, < 0.14"
+  required_version = ">= 0.12.7, <= 0.14"
 
   required_providers {
     aws      = ">= 2.70, < 4.0"

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.12.7, <= 0.14"
+  required_version = ">= 0.12.7"
 
   required_providers {
-    aws      = ">= 2.70, < 4.0"
+    aws      = ">= 2.70"
     template = ">= 2.0"
   }
 }


### PR DESCRIPTION
This will allow folks on Terraform 0.14 to use this module by setting the minimal supported Terraform version. This is aligned with [Terraforms best practices around versioning](https://www.terraform.io/docs/configuration/version-constraints.html#terraform-core-and-provider-versions). CI tests will also will be using the same version. Lastly. this PR cleans up the CircleCI config and updates pre-commit hooks.  

Once merged, I will remove the `terraform011` branch.

Resolves https://github.com/trussworks/terraform-aws-config/issues/99