### PR TITLE
Support attaching rules to an existing AWS Config recorder.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.33.0
+    rev: v1.36.0
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ module "aws_config" {
 | check\_vpc\_default\_security\_group\_closed | Enable vpc-default-security-group-closed rule | `bool` | `true` | no |
 | config\_aggregator\_name | The name of the aggregator. | `string` | `"organization"` | no |
 | config\_delivery\_frequency | The frequency with which AWS Config delivers configuration snapshots. | `string` | `"Six_Hours"` | no |
-| config\_logs\_bucket | The S3 bucket for AWS Config logs. | `string` | n/a | yes |
+| config\_logs\_bucket | The S3 bucket for AWS Config logs. If you have set enable\_config\_recorder to false then this can be an empty string. | `string` | n/a | yes |
 | config\_logs\_prefix | The S3 prefix for AWS Config logs. | `string` | `"config"` | no |
 | config\_max\_execution\_frequency | The maximum frequency with which AWS Config runs evaluations for a rule. | `string` | `"TwentyFour_Hours"` | no |
 | config\_name | The name of the AWS Config instance. | `string` | `"aws-config"` | no |

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ module "aws_config" {
 | config\_max\_execution\_frequency | The maximum frequency with which AWS Config runs evaluations for a rule. | `string` | `"TwentyFour_Hours"` | no |
 | config\_name | The name of the AWS Config instance. | `string` | `"aws-config"` | no |
 | config\_sns\_topic\_arn | An SNS topic to stream configuration changes and notifications to. | `string` | `null` | no |
+| enable\_config\_recorder | Enables configuring the AWS Config recorder resources in this module. | `bool` | `true` | no |
 | include\_global\_resource\_types | Specifies whether AWS Config includes all supported types of global resources with the resources that it records. | `bool` | `true` | no |
 | password\_max\_age | Number of days before password expiration. | `number` | `90` | no |
 | password\_min\_length | Password minimum length. | `number` | `14` | no |

--- a/config-service.tf
+++ b/config-service.tf
@@ -3,12 +3,16 @@
 #
 
 resource "aws_config_configuration_recorder_status" "main" {
+  count = var.enable_config_recorder ? 1 : 0
+
   name       = var.config_name
   is_enabled = true
   depends_on = [aws_config_delivery_channel.main]
 }
 
 resource "aws_config_delivery_channel" "main" {
+  count = var.enable_config_recorder ? 1 : 0
+
   name           = var.config_name
   s3_bucket_name = var.config_logs_bucket
   s3_key_prefix  = var.config_logs_prefix
@@ -22,8 +26,10 @@ resource "aws_config_delivery_channel" "main" {
 }
 
 resource "aws_config_configuration_recorder" "main" {
+  count = var.enable_config_recorder ? 1 : 0
+
   name     = var.config_name
-  role_arn = aws_iam_role.main.arn
+  role_arn = aws_iam_role.main[count.index].arn
 
   recording_group {
     all_supported                 = true

--- a/iam.tf
+++ b/iam.tf
@@ -68,22 +68,30 @@ data "aws_iam_policy_document" "aws-config-role-policy" {
 #
 
 resource "aws_iam_role" "main" {
+  count = var.enable_config_recorder ? 1 : 0
+
   name               = "${var.config_name}-role"
   assume_role_policy = data.aws_iam_policy_document.aws-config-role-policy.json
   tags               = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "managed-policy" {
-  role       = aws_iam_role.main.name
+  count = var.enable_config_recorder ? 1 : 0
+
+  role       = aws_iam_role.main[count.index].name
   policy_arn = format("arn:%s:iam::aws:policy/service-role/AWS_ConfigRole", data.aws_partition.current.partition)
 }
 
 resource "aws_iam_policy" "aws-config-policy" {
+  count = var.enable_config_recorder ? 1 : 0
+
   name   = "${var.config_name}-policy"
   policy = data.template_file.aws_config_policy.rendered
 }
 
 resource "aws_iam_role_policy_attachment" "aws-config-policy" {
-  role       = aws_iam_role.main.name
-  policy_arn = aws_iam_policy.aws-config-policy.arn
+  count = var.enable_config_recorder ? 1 : 0
+
+  role       = aws_iam_role.main[count.index].name
+  policy_arn = aws_iam_policy.aws-config-policy[0].arn
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,10 +5,10 @@ output "required_tags_rule_arn" {
 
 output "aws_config_role_arn" {
   description = "The ARN of the AWS config role."
-  value       = aws_iam_role.main.arn
+  value       = concat(aws_iam_role.main.*.arn, [""])[0]
 }
 
 output "aws_config_role_name" {
   description = "The name of the IAM role used by AWS config"
-  value       = aws_iam_role.main.name
+  value       = concat(aws_iam_role.main.*.name, [""])[0]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -284,3 +284,9 @@ variable "config_sns_topic_arn" {
   type        = string
   default     = null
 }
+
+variable "enable_config_recorder" {
+  description = "Enables configuring the AWS Config recorder resources in this module."
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "aggregate_organization" {
 }
 
 variable "config_logs_bucket" {
-  description = "The S3 bucket for AWS Config logs."
+  description = "The S3 bucket for AWS Config logs. If you have set enable_config_recorder to false then this can be an empty string."
   type        = string
 }
 


### PR DESCRIPTION
Some environments we run in already have AWS Config provisioned. So in order to no conflict with that this PR adds support for conditionally creating the recorder AWS resources. The existing rules will still get attached to the existing AWS Config recorder if enable_config_recorder is false. 

In addition to tests passing, I've also verified this isn't a breaking upgrade.