### PR TITLE
Create the option to pass in kms key ARN for config logs bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ No modules.
 | config\_aggregator\_name | The name of the aggregator. | `string` | `"organization"` | no |
 | config\_delivery\_frequency | The frequency with which AWS Config delivers configuration snapshots. | `string` | `"Six_Hours"` | no |
 | config\_logs\_bucket | The S3 bucket for AWS Config logs. If you have set enable\_config\_recorder to false then this can be an empty string. | `string` | n/a | yes |
+| config\_logs\_bucket\_kms\_key\_arn | The ARN of the AWS KMS key used to encrypt objects delivered by AWS Config. Must belong to the same Region as the destination S3 bucket. | `string` | `null` | no |
 | config\_logs\_prefix | The S3 prefix for AWS Config logs. | `string` | `"config"` | no |
 | config\_max\_execution\_frequency | The maximum frequency with which AWS Config runs evaluations for a rule. | `string` | `"TwentyFour_Hours"` | no |
 | config\_name | The name of the AWS Config instance. | `string` | `"aws-config"` | no |

--- a/config-service.tf
+++ b/config-service.tf
@@ -16,6 +16,7 @@ resource "aws_config_delivery_channel" "main" {
   name           = var.config_name
   s3_bucket_name = var.config_logs_bucket
   s3_key_prefix  = var.config_logs_prefix
+  s3_kms_key_arn = var.config_logs_bucket_kms_key_arn
   sns_topic_arn  = var.config_sns_topic_arn
 
   snapshot_delivery_properties {

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "config_logs_prefix" {
   default     = "config"
 }
 
+variable "config_logs_bucket_kms_key_arn" {
+  description = "The ARN of the AWS KMS key used to encrypt objects delivered by AWS Config. Must belong to the same Region as the destination S3 bucket."
+  type        = string
+  default     = null
+}
+
 variable "config_max_execution_frequency" {
   description = "The maximum frequency with which AWS Config runs evaluations for a rule."
   type        = string


### PR DESCRIPTION
Signed-off-by: Ivan Dechovski <ivandechovsky27@gmail.com>

Changes proposed in this pull request:

Allow passing in the KMS key ARN used to encrypt objects delivered by AWS Config to the target bucket. The option is already available in the terraform resource, this PR just allows it to be configured by the module.
