### PR TITLE
ci: removing pr limit from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,7 +42,6 @@
       ]
     }
   ],
-  "prConcurrentLimit": 2,
   "schedule": [
     "every weekend"
   ],


### PR DESCRIPTION
Removing PR limit from renovate to allow it to create all the PRs it needs to.
