### PR TITLE
Add option to pass in permissions boundary for IAM roles created for …

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ No modules.
 | config\_logs\_prefix | The S3 prefix for AWS Config logs. | `string` | `"config"` | no |
 | config\_max\_execution\_frequency | The maximum frequency with which AWS Config runs evaluations for a rule. | `string` | `"TwentyFour_Hours"` | no |
 | config\_name | The name of the AWS Config instance. | `string` | `"aws-config"` | no |
+| config\_role\_permissions\_boundary | The ARN of the permissions boundary to apply to IAM roles created for AWS Config | `string` | `null` | no |
 | config\_sns\_topic\_arn | An SNS topic to stream configuration changes and notifications to. | `string` | `null` | no |
 | cw\_loggroup\_retention\_period | Retention period for cloudwatch logs in number of days | `number` | `3653` | no |
 | dynamodb\_arn\_encryption\_list | Comma separated list of AWS KMS key ARNs allowed for encrypting Amazon DynamoDB Tables. | `string` | `"example,CSV"` | no |

--- a/config-aggregator.tf
+++ b/config-aggregator.tf
@@ -16,10 +16,11 @@ data "aws_iam_policy_document" "aws_config_aggregator_role_policy" {
 }
 
 resource "aws_iam_role" "aggregator" {
-  count              = var.aggregate_organization ? 1 : 0
-  name               = "${var.config_name}-aggregator-role"
-  tags               = var.tags
-  assume_role_policy = data.aws_iam_policy_document.aws_config_aggregator_role_policy.json
+  count                = var.aggregate_organization ? 1 : 0
+  name                 = "${var.config_name}-aggregator-role"
+  assume_role_policy   = data.aws_iam_policy_document.aws_config_aggregator_role_policy.json
+  permissions_boundary = var.config_role_permissions_boundary
+  tags                 = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "aggregator" {

--- a/iam.tf
+++ b/iam.tf
@@ -68,11 +68,11 @@ data "aws_iam_policy_document" "aws-config-role-policy" {
 #
 
 resource "aws_iam_role" "main" {
-  count = var.enable_config_recorder ? 1 : 0
-
-  name               = "${var.config_name}-role"
-  assume_role_policy = data.aws_iam_policy_document.aws-config-role-policy.json
-  tags               = var.tags
+  count                = var.enable_config_recorder ? 1 : 0
+  name                 = "${var.config_name}-role"
+  assume_role_policy   = data.aws_iam_policy_document.aws-config-role-policy.json
+  permissions_boundary = var.config_role_permissions_boundary
+  tags                 = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "managed-policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "aggregate_organization" {
   default     = false
 }
 
+variable "config_role_permissions_boundary" {
+  description = "The ARN of the permissions boundary to apply to IAM roles created for AWS Config"
+  type        = string
+  default     = null
+}
+
 variable "config_logs_bucket" {
   description = "The S3 bucket for AWS Config logs. If you have set enable_config_recorder to false then this can be an empty string."
   type        = string


### PR DESCRIPTION
…AWS Config

Signed-off-by: Ivan Dechovski <ivan>

Add the ability to pass in a permissions boundary ARN to the two roles created by the module for AWS Config
