### PR TITLE
Inputs for check_vpc_sg_open_only_to_authorized_ports rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ No modules.
 | resource\_types | A list that specifies the types of AWS resources for which AWS Config records configuration changes (for example, AWS::EC2::Instance or AWS::CloudTrail::Trail). See relevant part of AWS Docs for available types. | `list(string)` | `[]` | no |
 | s3\_bucket\_public\_access\_prohibited\_exclusion | Comma-separated list of known allowed public Amazon S3 bucket names. | `string` | `"example,CSV"` | no |
 | tags | Tags to apply to AWS Config resources | `map(string)` | `{}` | no |
-| vpc\_sg\_authorized\_TCP\_ports | Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025'. vpc\_sg\_authorized\_UDP\_ports required as well | `string` | `"example,CSV"` | no |
-| vpc\_sg\_authorized\_UDP\_ports | Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025'. vpc\_sg\_authorized\_TCP\_ports required as well | `string` | `"example,CSV"` | no |
+| vpc\_sg\_authorized\_TCP\_ports | Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025' | `string` | `null` | no |
+| vpc\_sg\_authorized\_UDP\_ports | Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025' | `string` | `null` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ No modules.
 | resource\_types | A list that specifies the types of AWS resources for which AWS Config records configuration changes (for example, AWS::EC2::Instance or AWS::CloudTrail::Trail). See relevant part of AWS Docs for available types. | `list(string)` | `[]` | no |
 | s3\_bucket\_public\_access\_prohibited\_exclusion | Comma-separated list of known allowed public Amazon S3 bucket names. | `string` | `"example,CSV"` | no |
 | tags | Tags to apply to AWS Config resources | `map(string)` | `{}` | no |
-| vpc\_sg\_authorized\_TCP\_ports | Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025' | `string` | `null` | no |
-| vpc\_sg\_authorized\_UDP\_ports | Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025' | `string` | `null` | no |
+| vpc\_sg\_authorized\_TCP\_ports | Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025' | `string` | `"none"` | no |
+| vpc\_sg\_authorized\_UDP\_ports | Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025' | `string` | `"none"` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ No modules.
 | resource\_types | A list that specifies the types of AWS resources for which AWS Config records configuration changes (for example, AWS::EC2::Instance or AWS::CloudTrail::Trail). See relevant part of AWS Docs for available types. | `list(string)` | `[]` | no |
 | s3\_bucket\_public\_access\_prohibited\_exclusion | Comma-separated list of known allowed public Amazon S3 bucket names. | `string` | `"example,CSV"` | no |
 | tags | Tags to apply to AWS Config resources | `map(string)` | `{}` | no |
-| vpc\_sg\_authorized\_TCP\_ports | Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025' | `string` | `"example,CSV"` | no |
-| vpc\_sg\_authorized\_UDP\_ports | Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025' | `string` | `"example,CSV"` | no |
+| vpc\_sg\_authorized\_TCP\_ports | Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025'. vpc\_sg\_authorized\_UDP\_ports required as well | `string` | `"example,CSV"` | no |
+| vpc\_sg\_authorized\_UDP\_ports | Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025'. vpc\_sg\_authorized\_TCP\_ports required as well | `string` | `"example,CSV"` | no |
 
 ## Outputs
 

--- a/config-policies/vpc_sg_authorized_ports.tpl
+++ b/config-policies/vpc_sg_authorized_ports.tpl
@@ -1,4 +1,4 @@
 {
-    "vpc_sg_authorized_TCP_ports": "${authorizedTcpPorts}",
-    "vpc_sg_authorized_UDP_ports": "${authorizedUdpPorts}"
+    "authorizedTcpPorts": "${vpc_sg_authorized_TCP_ports}",
+    "authorizedUdpPorts": "${vpc_sg_authorized_UDP_ports}"
 }

--- a/config-policies/vpc_sg_authorized_ports.tpl
+++ b/config-policies/vpc_sg_authorized_ports.tpl
@@ -1,0 +1,4 @@
+{
+    "vpc_sg_authorized_TCP_ports": "${authorizedTcpPorts}",
+    "vpc_sg_authorized_UDP_ports": "${authorizedUdpPorts}"
+}

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -943,9 +943,9 @@ resource "aws_config_config_rule" "s3-bucket-server-side-encryption-enabled" {
 }
 
 resource "aws_config_config_rule" "vpc-sg-open-only-to-authorized-ports" {
-  count       = var.check_vpc_sg_open_only_to_authorized_ports ? 1 : 0
-  name        = "vpc-sg-open-only-to-authorized-ports"
-  description = "Checks whether any security groups with inbound 0.0.0.0/0 have TCP or UDP ports accessible. The rule is NON_COMPLIANT when a security group with inbound 0.0.0.0/0 has a port accessible which is not specified in the rule parameters. "
+  count            = var.check_vpc_sg_open_only_to_authorized_ports ? 1 : 0
+  name             = "vpc-sg-open-only-to-authorized-ports"
+  description      = "Checks whether any security groups with inbound 0.0.0.0/0 have TCP or UDP ports accessible. The rule is NON_COMPLIANT when a security group with inbound 0.0.0.0/0 has a port accessible which is not specified in the rule parameters. "
   input_parameters = local.aws_config_vpc_sg_authorized_ports
 
   source {

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -945,7 +945,7 @@ resource "aws_config_config_rule" "s3-bucket-server-side-encryption-enabled" {
 resource "aws_config_config_rule" "vpc-sg-open-only-to-authorized-ports" {
   count            = var.check_vpc_sg_open_only_to_authorized_ports ? 1 : 0
   name             = "vpc-sg-open-only-to-authorized-ports"
-  description      = "Checks whether any security groups with inbound 0.0.0.0/0 have TCP or UDP ports accessible. The rule is NON_COMPLIANT when a security group with inbound 0.0.0.0/0 has a port accessible which is not specified in the rule parameters. "
+  description      = "Checks whether any security groups with inbound 0.0.0.0/0 have TCP or UDP ports accessible. NON_COMPLIANT when a security group with inbound 0.0.0.0/0 has a port accessible which is not specified in the rule parameters. If enabled, requires vpc_sg_authorized_TCP_ports and vpc_sg_authorized_UDP_ports declared in terraform"
   input_parameters = local.aws_config_vpc_sg_authorized_ports
 
   source {

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -945,7 +945,7 @@ resource "aws_config_config_rule" "s3-bucket-server-side-encryption-enabled" {
 resource "aws_config_config_rule" "vpc-sg-open-only-to-authorized-ports" {
   count            = var.check_vpc_sg_open_only_to_authorized_ports ? 1 : 0
   name             = "vpc-sg-open-only-to-authorized-ports"
-  description      = "Checks whether any security groups with inbound 0.0.0.0/0 have TCP or UDP ports accessible. NON_COMPLIANT when a security group with inbound 0.0.0.0/0 has a port accessible which is not specified in the rule parameters. If enabled, requires vpc_sg_authorized_TCP_ports and vpc_sg_authorized_UDP_ports declared in terraform"
+  description      = "Checks if security groups with inbound 0.0.0.0/0 have TCP or UDP ports accessible. NON_COMPLIANT if security group with inbound 0.0.0.0/0 has a port accessible which is not specified in rule parameters.(both Terraform inputs required if enabled)"
   input_parameters = local.aws_config_vpc_sg_authorized_ports
 
   source {

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -82,6 +82,13 @@ locals {
       s3_bucket_public_access_prohibited_exclusion = var.s3_bucket_public_access_prohibited_exclusion
     }
   )
+
+  aws_config_vpc_sg_authorized_ports = templatefile("${path.module}/config-policies/vpc_sg_authorized_ports.tpl",
+    {
+      vpc_sg_authorized_TCP_ports = var.vpc_sg_authorized_TCP_ports
+      vpc_sg_authorized_UDP_ports = var.vpc_sg_authorized_UDP_ports
+    }
+  )
 }
 
 
@@ -939,6 +946,7 @@ resource "aws_config_config_rule" "vpc-sg-open-only-to-authorized-ports" {
   count       = var.check_vpc_sg_open_only_to_authorized_ports ? 1 : 0
   name        = "vpc-sg-open-only-to-authorized-ports"
   description = "Checks whether any security groups with inbound 0.0.0.0/0 have TCP or UDP ports accessible. The rule is NON_COMPLIANT when a security group with inbound 0.0.0.0/0 has a port accessible which is not specified in the rule parameters. "
+  input_parameters = local.aws_config_vpc_sg_authorized_ports
 
   source {
     owner             = "AWS"

--- a/variables.tf
+++ b/variables.tf
@@ -526,15 +526,15 @@ variable "check_vpc_sg_open_only_to_authorized_ports" {
 }
 
 variable "vpc_sg_authorized_TCP_ports" {
-  description = "Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash."
+  description = "Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025'"
   type        = string
-  default     = "example,443,1020-1025"
+  default     = "example,CSV"
 }
 
 variable "vpc_sg_authorized_UDP_ports" {
-  description = "Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash."
+  description = "Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025'"
   type        = string
-  default     = "example,500,1020-1025"
+  default     = "example,CSV"
 }
 
 variable "resource_types" {

--- a/variables.tf
+++ b/variables.tf
@@ -554,3 +554,15 @@ variable "check_ebs_optimized_instance" {
   type        = bool
   default     = false
 }
+
+variable "vpc_sg_authorized_TCP_ports" {
+  description = "Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash."
+  type        = string
+  default     = "example,443,1020-1025"
+}
+
+variable "vpc_sg_authorized_UDP_ports" {
+  description = "Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash."
+  type        = string
+  default     = "example,500,1020-1025"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -525,6 +525,18 @@ variable "check_vpc_sg_open_only_to_authorized_ports" {
   default     = false
 }
 
+variable "vpc_sg_authorized_TCP_ports" {
+  description = "Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash."
+  type        = string
+  default     = "example,443,1020-1025"
+}
+
+variable "vpc_sg_authorized_UDP_ports" {
+  description = "Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash."
+  type        = string
+  default     = "example,500,1020-1025"
+}
+
 variable "resource_types" {
   description = "A list that specifies the types of AWS resources for which AWS Config records configuration changes (for example, AWS::EC2::Instance or AWS::CloudTrail::Trail). See relevant part of AWS Docs for available types."
   type        = list(string)
@@ -553,16 +565,4 @@ variable "check_ebs_optimized_instance" {
   description = "Enable ebs-optimized-instance-check rule"
   type        = bool
   default     = false
-}
-
-variable "vpc_sg_authorized_TCP_ports" {
-  description = "Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash."
-  type        = string
-  default     = "example,443,1020-1025"
-}
-
-variable "vpc_sg_authorized_UDP_ports" {
-  description = "Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash."
-  type        = string
-  default     = "example,500,1020-1025"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -526,15 +526,15 @@ variable "check_vpc_sg_open_only_to_authorized_ports" {
 }
 
 variable "vpc_sg_authorized_TCP_ports" {
-  description = "Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025'. vpc_sg_authorized_UDP_ports required as well"
+  description = "Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025'"
   type        = string
-  default     = "example,CSV"
+  default     = null
 }
 
 variable "vpc_sg_authorized_UDP_ports" {
-  description = "Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025'. vpc_sg_authorized_TCP_ports required as well"
+  description = "Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025'"
   type        = string
-  default     = "example,CSV"
+  default     = null
 }
 
 variable "resource_types" {

--- a/variables.tf
+++ b/variables.tf
@@ -528,13 +528,15 @@ variable "check_vpc_sg_open_only_to_authorized_ports" {
 variable "vpc_sg_authorized_TCP_ports" {
   description = "Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025'"
   type        = string
-  default     = null
+  #default value can't be blank
+  default = "none"
 }
 
 variable "vpc_sg_authorized_UDP_ports" {
   description = "Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025'"
   type        = string
-  default     = null
+  #default value can't be blank
+  default = "none"
 }
 
 variable "resource_types" {

--- a/variables.tf
+++ b/variables.tf
@@ -526,13 +526,13 @@ variable "check_vpc_sg_open_only_to_authorized_ports" {
 }
 
 variable "vpc_sg_authorized_TCP_ports" {
-  description = "Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025'"
+  description = "Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025'. vpc_sg_authorized_UDP_ports required as well"
   type        = string
   default     = "example,CSV"
 }
 
 variable "vpc_sg_authorized_UDP_ports" {
-  description = "Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025'"
+  description = "Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025'. vpc_sg_authorized_TCP_ports required as well"
   type        = string
   default     = "example,CSV"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -522,7 +522,7 @@ variable "check_s3_bucket_server_side_encryption_enabled" {
 variable "check_vpc_sg_open_only_to_authorized_ports" {
   description = "Enable vpc-sg-open-only-to-authorized-ports rule"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "resource_types" {


### PR DESCRIPTION
Changes proposed in this pull request:

- check_vpc_sg_open_only_to_authorized_ports rule will now be disabled by default.
- Added Authorized TCP and UDP port inputs for check_vpc_sg_open_only_to_authorized_ports rule. 
