### PR TITLE
fix: rds cluster deletion protection rule

### DIFF
--- a/config-rules.tf
+++ b/config-rules.tf
@@ -869,11 +869,11 @@ resource "aws_config_config_rule" "rds-snapshot-encrypted" {
 resource "aws_config_config_rule" "rds-cluster-deletion-protection-enabled" {
   count       = var.check_rds_cluster_deletion_protection_enabled ? 1 : 0
   name        = "rds-cluster-deletion-protection-enabled"
-  description = "Checks whether Amazon Relational Database Service (Amazon RDS) DB snapshots are encrypted. The rule is NON_COMPLIANT, if the Amazon RDS DB snapshots are not encrypted."
+  description = "Checks if an Amazon Relational Database Service (Amazon RDS) cluster has deletion protection enabled. The rule is NON_COMPLIANT if an Amazon RDS cluster does not have deletion protection enabled."
 
   source {
     owner             = "AWS"
-    source_identifier = "RDS_SNAPSHOT_ENCRYPTED"
+    source_identifier = "RDS_CLUSTER_DELETION_PROTECTION_ENABLED"
   }
 
   tags = var.tags


### PR DESCRIPTION
Changes proposed in this pull request:

- fix wrong rule for var `check_rds_cluster_deletion_protection_enabled`. It should create deletion protection rule for rds cluster `RDS_CLUSTER_DELETION_PROTECTION_ENABLED` but instead it was creating `RDS_SNAPSHOT_ENCRYPTED` rule

https://docs.aws.amazon.com/config/latest/developerguide/rds-instance-deletion-protection-enabled.html
