### PR TITLE
adds missing permissions for encrypted sns topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ No modules.
 | required\_tags\_resource\_types | Resource types to check for tags. | `list(string)` | `[]` | no |
 | resource\_types | A list that specifies the types of AWS resources for which AWS Config records configuration changes (for example, AWS::EC2::Instance or AWS::CloudTrail::Trail). See relevant part of AWS Docs for available types. | `list(string)` | `[]` | no |
 | s3\_bucket\_public\_access\_prohibited\_exclusion | Comma-separated list of known allowed public Amazon S3 bucket names. | `string` | `"example,CSV"` | no |
+| sns\_kms\_key\_id | The ARN of the KMS key used to encrypt the Amazon SNS topic. | `string` | `null` | no |
 | tags | Tags to apply to AWS Config resources | `map(string)` | `{}` | no |
 | vpc\_sg\_authorized\_TCP\_ports | Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025' | `string` | `"none"` | no |
 | vpc\_sg\_authorized\_UDP\_ports | Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025' | `string` | `"none"` | no |

--- a/examples/encrypted-sns-topic/main.tf
+++ b/examples/encrypted-sns-topic/main.tf
@@ -1,0 +1,76 @@
+data "aws_partition" "current" {}
+
+#
+# AWS Config Logs Bucket
+#
+
+module "config_logs" {
+  source  = "trussworks/logs/aws"
+  version = "~> 10"
+
+  s3_bucket_name     = var.config_logs_bucket
+  allow_config       = true
+  config_logs_prefix = "config"
+  force_destroy      = true
+}
+
+#
+# SNS Topic
+#
+
+data "aws_iam_policy_document" "config" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [module.config.aws_config_role_arn]
+    }
+    actions   = ["SNS:Publish"]
+    resources = [aws_sns_topic.config.arn]
+  }
+}
+
+resource "aws_sns_topic" "config" {
+  name              = var.config_name
+  kms_master_key_id = module.sns_key.key_arn
+}
+
+resource "aws_sns_topic_policy" "config" {
+  arn    = aws_sns_topic.config.arn
+  policy = data.aws_iam_policy_document.config.json
+}
+
+#
+# KMS Key for SNS
+#
+module "sns_key" {
+  source      = "terraform-aws-modules/kms/aws"
+  version     = "~> 1.5.0"
+  description = "Key for SNS usage"
+  key_usage   = "ENCRYPT_DECRYPT"
+
+  # Policy
+  key_users = [module.config.aws_config_role_arn]
+
+  # Aliases
+  aliases = ["theydo/sns"]
+}
+
+#
+# AWS Config
+#
+
+module "config" {
+  source = "../../"
+
+  config_name          = var.config_name
+  config_logs_bucket   = module.config_logs.aws_logs_bucket
+  config_logs_prefix   = "config"
+  config_sns_topic_arn = aws_sns_topic.config.arn
+  sns_kms_key_id       = module.sns_key.key_arn
+
+  tags = {
+    "Automation" = "Terraform"
+    "Name"       = var.config_name
+  }
+}

--- a/examples/encrypted-sns-topic/variables.tf
+++ b/examples/encrypted-sns-topic/variables.tf
@@ -1,0 +1,11 @@
+variable "config_name" {
+  type = string
+}
+
+variable "config_logs_bucket" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}

--- a/iam.tf
+++ b/iam.tf
@@ -17,6 +17,30 @@ data "aws_iam_policy_document" "aws_config_policy" {
     ]
   }
 
+  dynamic "statement" {
+    for_each = var.sns_kms_key_id != null ? [1] : []
+    content {
+      sid    = "AWSAllowKMSKeyUsage"
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey*"
+      ]
+      resources = [var.sns_kms_key_id]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.sns_kms_key_id != null ? [1] : []
+    content {
+      sid    = "AWSAllowSNSPublish"
+      effect = "Allow"
+      actions = [
+        "sns:Publish"
+      ]
+      resources = [var.config_sns_topic_arn]
+    }
+  }
 
   statement {
     sid    = "AWSConfigBucketExistenceCheck"

--- a/variables.tf
+++ b/variables.tf
@@ -568,3 +568,9 @@ variable "check_ebs_optimized_instance" {
   type        = bool
   default     = false
 }
+
+variable "sns_kms_key_id" {
+  description = "The ARN of the KMS key used to encrypt the Amazon SNS topic."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Changes proposed in this pull request:

This pull request adds missing permissions on the role associated with the AWS config to be able to use encrypted SNS topics. When an SNS topic is encrypted, additional permissions need to be added to the role or service that is publishing the messages to SNS. 

The documentation on AWS config is not clear about this but you can find other examples on AWS for other services that explicitly say the required permissions to be able to publish messages on encrypted SNS topics. For example:
* https://repost.aws/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger
* https://docs.aws.amazon.com/devops-guru/latest/userguide/sns-kms-permissions.html

This pull request also adds an example with an encrypted SNS topic.