### PR TITLE
Fix inputs for check_vpc_sg_open_only_to_authorized_ports rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,7 @@ No modules.
 | resource\_types | A list that specifies the types of AWS resources for which AWS Config records configuration changes (for example, AWS::EC2::Instance or AWS::CloudTrail::Trail). See relevant part of AWS Docs for available types. | `list(string)` | `[]` | no |
 | s3\_bucket\_public\_access\_prohibited\_exclusion | Comma-separated list of known allowed public Amazon S3 bucket names. | `string` | `"example,CSV"` | no |
 | tags | Tags to apply to AWS Config resources | `map(string)` | `{}` | no |
-| vpc\_sg\_authorized\_TCP\_ports | Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025' | `string` | `"none"` | no |
-| vpc\_sg\_authorized\_UDP\_ports | Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025' | `string` | `"none"` | no |
+| vpc\_sg\_authorized\_ports | Object with values as Comma-separated list of ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025' | ```object({ authorizedTcpPorts = optional(string, null) authorizedUdpPorts = optional(string, null) })``` | `{}` | no |
 
 ## Outputs
 

--- a/config-policies/vpc_sg_authorized_ports.tpl
+++ b/config-policies/vpc_sg_authorized_ports.tpl
@@ -1,4 +1,0 @@
-{
-    "authorizedTcpPorts": "${vpc_sg_authorized_TCP_ports}",
-    "authorizedUdpPorts": "${vpc_sg_authorized_UDP_ports}"
-}

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -83,12 +83,8 @@ locals {
     }
   )
 
-  aws_config_vpc_sg_authorized_ports = templatefile("${path.module}/config-policies/vpc_sg_authorized_ports.tpl",
-    {
-      vpc_sg_authorized_TCP_ports = var.vpc_sg_authorized_TCP_ports
-      vpc_sg_authorized_UDP_ports = var.vpc_sg_authorized_UDP_ports
-    }
-  )
+  aws_config_vpc_sg_authorized_ports = jsonencode({ for k, v in var.vpc_sg_authorized_ports : k => tostring(v) if v != null })
+
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -525,18 +525,13 @@ variable "check_vpc_sg_open_only_to_authorized_ports" {
   default     = false
 }
 
-variable "vpc_sg_authorized_TCP_ports" {
-  description = "Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025'"
-  type        = string
-  #default value can't be blank
-  default = "none"
-}
-
-variable "vpc_sg_authorized_UDP_ports" {
-  description = "Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '500,1020-1025'"
-  type        = string
-  #default value can't be blank
-  default = "none"
+variable "vpc_sg_authorized_ports" {
+  description = "Object with values as Comma-separated list of ports authorized to be open to 0.0.0.0/0. Ranges are defined by dash. example, '443,1020-1025'"
+  type = object({
+    authorizedTcpPorts = optional(string, null)
+    authorizedUdpPorts = optional(string, null)
+  })
+  default = {}
 }
 
 variable "resource_types" {


### PR DESCRIPTION

Changes proposed in this pull request:

- fix authorized ports so does not pass null string as value if var is not used. Also no longer breaks.

