### PR TITLE
fix(config-service): Supply INCLUSION_BY_RESOURCE_TYPES when resource_types are defined.

### DIFF
--- a/config-service.tf
+++ b/config-service.tf
@@ -36,5 +36,8 @@ resource "aws_config_configuration_recorder" "main" {
     all_supported                 = length(var.resource_types) == 0 ? true : false
     include_global_resource_types = length(var.resource_types) == 0 ? var.include_global_resource_types : null
     resource_types                = length(var.resource_types) == 0 ? null : var.resource_types
+    recording_strategy {
+      use_only = length(var.resource_types) == 0 ? "ALL_SUPPORTED_RESOURCE_TYPES" : "INCLUSION_BY_RESOURCE_TYPES"
+    }
   }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixes the `InvalidRecordingGroupException: The recording group provided is not valid` error when `resource_types` are defined.