### PR TITLE
Remove Obsolete Config Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,6 @@ No modules.
 | [aws_config_config_rule.iam-policy-no-statements-with-full-access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
 | [aws_config_config_rule.iam-user-no-policies-check](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
 | [aws_config_config_rule.iam_root_access_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
-| [aws_config_config_rule.instances-in-vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
 | [aws_config_config_rule.internet-gateway-authorized-vpc-only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
 | [aws_config_config_rule.mfa_enabled_for_iam_console_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
 | [aws_config_config_rule.multi-region-cloud-trail-enabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
@@ -201,7 +200,6 @@ No modules.
 | [aws_config_config_rule.s3-bucket-level-public-access-prohibited](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
 | [aws_config_config_rule.s3-bucket-public-read-prohibited](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
 | [aws_config_config_rule.s3-bucket-public-write-prohibited](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
-| [aws_config_config_rule.s3-bucket-server-side-encryption-enabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
 | [aws_config_config_rule.s3_bucket_ssl_requests_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
 | [aws_config_config_rule.vpc-sg-open-only-to-authorized-ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
 | [aws_config_config_rule.vpc_default_security_group_closed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
@@ -263,7 +261,6 @@ No modules.
 | check\_iam\_policy\_no\_statements\_with\_full\_access | Enable iam-policy-no-statements-with-full-access rule | `bool` | `true` | no |
 | check\_iam\_root\_access\_key | Enable iam-root-access-key rule | `bool` | `true` | no |
 | check\_iam\_user\_no\_policies\_check | Enable iam-user-no-policies-check rule | `bool` | `true` | no |
-| check\_instances\_in\_vpc | Enable instances-in-vpc rule | `bool` | `true` | no |
 | check\_internet\_gateway\_authorized\_vpc\_only | Enable internet-gateway-authorized-vpc-only rule | `bool` | `false` | no |
 | check\_mfa\_enabled\_for\_iam\_console\_access | Enable mfa-enabled-for-iam-console-access rule | `bool` | `true` | no |
 | check\_multi\_region\_cloud\_trail | Enable multi-region-cloud-trail-enabled rule | `bool` | `false` | no |
@@ -281,7 +278,6 @@ No modules.
 | check\_s3\_bucket\_level\_public\_access\_prohibited | Enable s3-bucket-level-public-access-prohibited rule | `bool` | `false` | no |
 | check\_s3\_bucket\_public\_read\_prohibited | Enable s3-bucket-public-read-prohibited rule | `bool` | `false` | no |
 | check\_s3\_bucket\_public\_write\_prohibited | Enable s3-bucket-public-write-prohibited rule | `bool` | `true` | no |
-| check\_s3\_bucket\_server\_side\_encryption\_enabled | Enable s3-bucket-server-side-encryption-enabled rule | `bool` | `true` | no |
 | check\_s3\_bucket\_ssl\_requests\_only | Enable s3-bucket-ssl-requests-only rule | `bool` | `true` | no |
 | check\_vpc\_default\_security\_group\_closed | Enable vpc-default-security-group-closed rule | `bool` | `true` | no |
 | check\_vpc\_sg\_open\_only\_to\_authorized\_ports | Enable vpc-sg-open-only-to-authorized-ports rule | `bool` | `false` | no |

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -178,21 +178,6 @@ resource "aws_config_config_rule" "cloud-trail-log-file-validation-enabled" {
   depends_on = [aws_config_configuration_recorder.main]
 }
 
-resource "aws_config_config_rule" "instances-in-vpc" {
-  count       = var.check_instances_in_vpc ? 1 : 0
-  name        = "instances-in-vpc"
-  description = "Ensure all EC2 instances run in a VPC"
-
-  source {
-    owner             = "AWS"
-    source_identifier = "INSTANCES_IN_VPC"
-  }
-
-  tags = var.tags
-
-  depends_on = [aws_config_configuration_recorder.main]
-}
-
 resource "aws_config_config_rule" "root-account-mfa-enabled" {
   count       = var.check_root_account_mfa_enabled ? 1 : 0
   name        = "root-account-mfa-enabled"
@@ -916,21 +901,6 @@ resource "aws_config_config_rule" "s3-bucket-acl-prohibited" {
   source {
     owner             = "AWS"
     source_identifier = "S3_BUCKET_ACL_PROHIBITED"
-  }
-
-  tags = var.tags
-
-  depends_on = [aws_config_configuration_recorder.main]
-}
-
-resource "aws_config_config_rule" "s3-bucket-server-side-encryption-enabled" {
-  count       = var.check_s3_bucket_server_side_encryption_enabled ? 1 : 0
-  name        = "s3-bucket-server-side-encryption-enabled"
-  description = "Checks if S3 bucket either has the S3 default encryption enabled or that S3 policy explicitly denies put-object requests without SSE that uses AES-256 or AWS KMS. The rule is NON_COMPLIANT if your Amazon S3 bucket is not encrypted by default."
-
-  source {
-    owner             = "AWS"
-    source_identifier = "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
   }
 
   tags = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -165,12 +165,6 @@ variable "required_tags" {
   default     = {}
 }
 
-variable "check_instances_in_vpc" {
-  description = "Enable instances-in-vpc rule"
-  type        = bool
-  default     = true
-}
-
 variable "check_acm_certificate_expiration_check" {
   description = "Enable acm-certificate-expiration-check rule"
   type        = bool
@@ -509,12 +503,6 @@ variable "s3_bucket_public_access_prohibited_exclusion" {
 
 variable "check_s3_bucket_acl_prohibited" {
   description = "Enable s3-bucket-acl-prohibited rule"
-  type        = bool
-  default     = true
-}
-
-variable "check_s3_bucket_server_side_encryption_enabled" {
-  description = "Enable s3-bucket-server-side-encryption-enabled rule"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
- EC2-Classic is now retired so instances must be attached to a VPC by default.
- S3 encryption is now the default.